### PR TITLE
Remove related surgical afflictions when eye surgery ends

### DIFF
--- a/Lua/Scripts/Server/items.lua
+++ b/Lua/Scripts/Server/items.lua
@@ -240,6 +240,10 @@ NTEYE.ItemMethods.advretractors = function(item, usingCharacter, targetCharacter
 	if HF.HasAffliction(targetCharacter, "sr_heldlid") then
 		HF.SetAfflictionLimb(targetCharacter, "sr_heldlid", limb, 0, usingCharacter) --remove held lids
 		HF.SetAfflictionLimb(targetCharacter, "sr_poppedeye", limb, 0, usingCharacter) --remove popped eyes
+		HF.SetAfflictionLimb(targetCharacter, "sr_eyeconnector", limb, 0, usingCharacter) --remove eye connector
+		HF.SetAfflictionLimb(targetCharacter, "sr_corneaincision", limb, 0, usingCharacter) --remove cornea incision
+		HF.SetAfflictionLimb(targetCharacter, "sr_emulsification", limb, 0, usingCharacter) --remove emulsification
+		HF.SetAfflictionLimb(targetCharacter, "sr_lasersurgery", limb, 0, usingCharacter) --remove laser surgery
 	else
 		--check if surgery can be performed
 		if not HF.CanPerformSurgeryOn(targetCharacter) then


### PR DESCRIPTION
I think that these surgical afflictions should be removed when surgery ends. Otherwise, they can linger indefinitely (except laser eye surgery, which decreases over time).

This also provides a way to cancel Cataract Surgery. This type of surgery may be accidentally started by failing to apply tweezers when attempting an Eye Removal Surgery. In any case, once the `Cornea Incision` or `Emulsification` afflictions are added, they linger indefinitely until a Cataract Surgery is completed, requiring a Needle and Organic Eye Lens. This change allows them to be removed when `Eye Lids Held` is removed.

The only surgical afflictions that I think should persist when `Eye Lids Held` is removed are `Removed Eye`, `Removed Eyes`, and `Eye Drops`.
