### PR TITLE
Fix single tick of pressure damage occurring during load

### DIFF
--- a/Lua/Scripts/Server/humanUpdate.lua
+++ b/Lua/Scripts/Server/humanUpdate.lua
@@ -15,7 +15,7 @@ local function PressureDamageCalculation(character, pressureDamageValue)
 
 	--return the damage value
 	return (
-		(character.InPressure and not (character.IsProtectedFromPressure or character.IsImmuneToPressure))
+		(character.InWater and character.InPressure and not (character.IsProtectedFromPressure or character.IsImmuneToPressure))
 		and pressureDamage
 	) or 0
 end


### PR DESCRIPTION
When loading a game, crew members take one instance of eye damage. I haven't tested if this happens at the start of every round or in every gamemode. For some reason, `character.InPressure` is true during that time, regardless of the character's actual position. Adding a check for `character.InWater` fixes the false positive, and shouldn't get in the way of real pressure damage since (as far as I know) there's no way to be in a pressurized environment without also being in water.